### PR TITLE
Lssttd 1352

### DIFF
--- a/python/lsst/eotest/sensor/fe55_psf.py
+++ b/python/lsst/eotest/sensor/fe55_psf.py
@@ -60,8 +60,8 @@ def cluster_moments(dn, pos):
 
 def pixel_integral(x, y, x0, y0, sigmax, sigmay):
     """
-    Integrate 2D Gaussian centered at (x0, y0) with scaled widths sqrt2sigmax and
-    sqrt2sigmay over a square pixel at (x, y) with unit width.
+    Integrate 2D Gaussian centered at (x0, y0) with widths sigmax and
+    sigmay over a square pixel at (x, y) with unit width.
 
     """
     x1 = x - 0.5


### PR DESCRIPTION
Two changes to speed up fe55 cluster fitting: vectorize call to pixel_integral and seed fit with cluster moments.

On a small test case I used these two changes:
1) give very similar results,
2) reduce the total time spend in the fitter from 71 seconds to 21 seconds,
3) reduce the amount of time spent evaluating the PSF integral from 51 seconds to 14 seconds.
