### PR TITLE
handle missing MONOWL keyword

### DIFF
--- a/python/lsst/eotest/raft/raft_mosaic.py
+++ b/python/lsst/eotest/raft/raft_mosaic.py
@@ -55,7 +55,10 @@ class RaftMosaic(object):
         self.fits_files = fits_files
         with fits.open(list(fits_files.values())[0]) as hdu_list:
             self.raft_name = hdu_list[0].header['RAFTNAME']
-            self.wl = hdu_list[0].header['MONOWL']
+            try:
+                self.wl = hdu_list[0].header['MONOWL']
+            except KeyError:
+                wl = 0
         self.image_array = np.zeros((nx, ny), dtype=np.float32)
         self.nx = nx
         self.ny = ny

--- a/python/lsst/eotest/sensor/EOTestPlots.py
+++ b/python/lsst/eotest/sensor/EOTestPlots.py
@@ -269,7 +269,7 @@ class EOTestPlots(object):
             xtalk_file = os.path.join(self.rootdir,
                                       '%s_xtalk_matrix.fits' % self.sensor_id)
         foo = CrosstalkMatrix(xtalk_file)
-        win = foo.plot(title="Crosstalk, %s" % self.sensor_id)
+        foo.plot(title="Crosstalk, %s" % self.sensor_id)
         return foo
 
     def persistence(self, infile=None, figsize=(11, 8.5)):
@@ -417,9 +417,11 @@ class EOTestPlots(object):
                 # Plot PTC curves using gain measurements.
                 ptc_gain = self.results['PTC_GAIN'][amp-1]
                 ptc_gain_error = self.results['PTC_GAIN_ERROR'][amp-1]
+                ptc_a00 = self.results['PTC_A00'][amp-1]
+                ptc_a00_error = self.results['PTC_A00_ERROR'][amp-1]
                 plot.curve(xx, xx/ptc_gain, oplot=1, color='b', lineStyle=':')
-                note = 'Amp %i\nGain = %.2f +/- %.2f'\
-                    % (amp, ptc_gain, ptc_gain_error)
+                note = 'Amp %i\nGain = %.2f +/- %.2f\nA00 = %.1e +/- %.1e'\
+                    % (amp, ptc_gain, ptc_gain_error, ptc_a00, ptc_a00_error)
                 pylab.annotate(note, (0.05, 0.9), xycoords='axes fraction',
                                verticalalignment='top', size='x-small')
 

--- a/python/lsst/eotest/sensor/EOTestPlots.py
+++ b/python/lsst/eotest/sensor/EOTestPlots.py
@@ -93,7 +93,10 @@ def plot_flat(infile, nsig=3, cmap=pylab.cm.hot, win=None, subplot=(1, 1, 1),
     with fits.open(infile) as foo:
         if wl is None:
             # Extract wavelength from file
-            wl = foo[0].header['MONOWL']
+            try:
+                wl = foo[0].header['MONOWL']
+            except KeyError:
+                wl = 0
         datasec = parse_geom_kwd(foo[1].header['DATASEC'])
         # Specialize to science sensor or wavefront sensor geometries.
         nx_segments = 8

--- a/python/lsst/eotest/sensor/EOTestResults.py
+++ b/python/lsst/eotest/sensor/EOTestResults.py
@@ -35,13 +35,14 @@ class EOTestResults(object):
         self.output = fits.HDUList()
         self.output.append(fits.PrimaryHDU())
         self.colnames = ["AMP", "GAIN", "GAIN_ERROR", "READ_NOISE", "FULL_WELL",
+                         "MAX_FRAC_DEV",
                          "CTI_HIGH_SERIAL", "CTI_HIGH_PARALLEL",
                          "CTI_LOW_SERIAL", "CTI_LOW_PARALLEL",
                          "DARK_CURRENT_95", "NUM_BRIGHT_PIXELS", "NUM_TRAPS"]
-        formats = "IEEEEEEEEEJJ"
+        formats = "IEEEEEEEEEEJJ"
         my_types = dict((("I", np.int), ("J", np.int), ("E", np.float)))
         columns = [np.zeros(self.namps, dtype=my_types[fmt]) for fmt in formats]
-        units = ["None", "Ne/DN", "Ne/DN", "rms e-/pixel", "e-/pixel",
+        units = ["None", "Ne/DN", "Ne/DN", "rms e-/pixel", "e-/pixel", "None",
                  "None", "None", "None", "None", "e-/s/pixel", "None", "None"]
         fits_cols = [fits.Column(name=self.colnames[i], format=formats[i],
                                  unit=units[i], array=columns[i])

--- a/python/lsst/eotest/sensor/EOTestResults.py
+++ b/python/lsst/eotest/sensor/EOTestResults.py
@@ -38,8 +38,8 @@ class EOTestResults(object):
                          "CTI_HIGH_SERIAL", "CTI_HIGH_PARALLEL",
                          "CTI_LOW_SERIAL", "CTI_LOW_PARALLEL",
                          "DARK_CURRENT_95", "NUM_BRIGHT_PIXELS", "NUM_TRAPS"]
-        formats = "IEEEEEEEEEII"
-        my_types = dict((("I", np.int), ("E", np.float)))
+        formats = "IEEEEEEEEEJJ"
+        my_types = dict((("I", np.int), ("J", np.int), ("E", np.float)))
         columns = [np.zeros(self.namps, dtype=my_types[fmt]) for fmt in formats]
         units = ["None", "Ne/DN", "Ne/DN", "rms e-/pixel", "e-/pixel",
                  "None", "None", "None", "None", "e-/s/pixel", "None", "None"]
@@ -63,7 +63,7 @@ class EOTestResults(object):
         """
         if colname in self.colnames:
             return
-        _types = dict(((int, 'I'), (float, 'E'), (np.float64, 'E')))
+        _types = dict(((int, 'J'), (float, 'E'), (np.float64, 'E')))
         if column is None:
             column = np.zeros(self.namps, dtype=dtype)
         new_cols = fits.ColDefs([fits.Column(name=colname,

--- a/python/lsst/eotest/sensor/darkCurrentTask.py
+++ b/python/lsst/eotest/sensor/darkCurrentTask.py
@@ -53,7 +53,10 @@ class DarkCurrentTask(pipeBase.Task):
         ccd = MaskedCCD(medfile, mask_files=mask_files, bias_frame=bias_frame)
 
         dark95s = {}
-        exptime = md.get('EXPTIME')
+        try:
+            exptime = md.get('DARKTIME')
+        except KeyError:
+            exptime = md.get('EXPTIME')
         if self.config.verbose:
             self.log.info("Amp        95 percentile    median")
         dark_curr_pixels = []


### PR DESCRIPTION
Also
* store integers in eotest results file as 32-bit ints
* use `DARKTIME` for computing dark current contribution
* add `MAX_FRAC_DEV` as a default column in eotest results file
* add `A00` values to annotation on PTC curve plots