### PR TITLE
Use np.mean() to evaluate mean of outlier-filtered difference images

### DIFF
--- a/python/lsst/eotest/sensor/ptcTask.py
+++ b/python/lsst/eotest/sensor/ptcTask.py
@@ -152,8 +152,7 @@ class PtcTask(pipeBase.Task):
         exposure = []
         seqnums = []
         dayobs = []
-        #file1s = sorted([item for item in infiles if item.find('flat1') != -1])
-        file1s = sorted([item for item in infiles if item.find('flat0') != -1])
+        file1s = sorted([item for item in infiles if item.find('flat1') != -1])
         for flat1 in file1s:
             flat2 = flat2_finder(flat1)
             if self.config.verbose:

--- a/python/lsst/eotest/sensor/ptcTask.py
+++ b/python/lsst/eotest/sensor/ptcTask.py
@@ -110,8 +110,8 @@ def flat_pair_stats(ccd1, ccd2, amp, mask_files=(), bias_frame=None):
         keep = np.where((np.abs(fdiff) < (mad*14.826)))[0]
 
         # Re-weight the images
-        mean1 = mean(image1[keep])
-        mean2 = mean(image2[keep])
+        mean1 = np.mean(image1[keep])
+        mean2 = np.mean(image2[keep])
         fmean = (mean1 + mean2)/2.
         weight1 = mean2/fmean
         weight2 = mean1/fmean

--- a/python/lsst/eotest/sensor/ptcTask.py
+++ b/python/lsst/eotest/sensor/ptcTask.py
@@ -110,8 +110,8 @@ def flat_pair_stats(ccd1, ccd2, amp, mask_files=(), bias_frame=None):
         keep = np.where((np.abs(fdiff) < (mad*14.826)))[0]
 
         # Re-weight the images
-        mean1 = np.mean(image1[keep])
-        mean2 = np.mean(image2[keep])
+        mean1 = np.mean(image1[keep], dtype=np.float64)
+        mean2 = np.mean(image2[keep], dtype=np.float64)
         fmean = (mean1 + mean2)/2.
         weight1 = mean2/fmean
         weight2 = mean1/fmean
@@ -152,7 +152,8 @@ class PtcTask(pipeBase.Task):
         exposure = []
         seqnums = []
         dayobs = []
-        file1s = sorted([item for item in infiles if item.find('flat1') != -1])
+        #file1s = sorted([item for item in infiles if item.find('flat1') != -1])
+        file1s = sorted([item for item in infiles if item.find('flat0') != -1])
         for flat1 in file1s:
             flat2 = flat2_finder(flat1)
             if self.config.verbose:


### PR DESCRIPTION
This change avoids a current gotcha with how afw.makeStatistics treats the filtered array of pixel values for the difference image by instead evaluating the mean using np.mean().  On the associated JIRA issue, I posted a plot showing that the change has the expected effect on the evaluated means (an ~0.5 ADU increase).